### PR TITLE
Docker new host name validation policy and OS X support

### DIFF
--- a/cluster-down.sh
+++ b/cluster-down.sh
@@ -1,5 +1,5 @@
 #!/bin/bash 
 
-docker kill $(docker ps -aq --filter "name=es_*")
-docker rm $(docker ps -aq --filter "name=es_*")
+docker kill $(docker ps -aq --filter "name=es*")
+docker rm $(docker ps -aq --filter "name=es*")
 rm -rf /tmp/es/{1,2,3}

--- a/cluster-up.sh
+++ b/cluster-up.sh
@@ -2,6 +2,12 @@
 
 set -ex
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "[OS X] Prepare VM for Docker..."
+    docker-machine start
+    eval $(docker-machine env)
+fi
+
 start_node() {
   docker run -d --name=$1 --hostname=$1 $2 -e "ES_HEAP_SIZE=512m" lis0x90/elasticsearch-flex \
      /usr/share/elasticsearch/bin/elasticsearch \

--- a/cluster-up.sh
+++ b/cluster-up.sh
@@ -1,4 +1,5 @@
 #!/bin/bash 
+
 set -ex
 
 start_node() {
@@ -7,17 +8,17 @@ start_node() {
        -Des.insecure.allow.root=true \
        --path.home=/usr/share/elasticsearch --path.logs=/var/log/elasticsearch --path.conf=/etc/elasticsearch \
        --network.host=_non_loopback:ipv4_ --discovery.zen.ping.multicast.enabled=true \
-       --node.name=$1 --cluster.name=esaas ${@:3} 
+       --node.name=$1 --cluster.name=esaas ${@:3}
 }
 
-start_node es_master1 "-p 9201:9200" --node.master=true --node.data=false --discovery.zen.minimum_master_nodes=2 --path.data=/tmp/
-start_node es_master2 "-p 9202:9200" --node.master=true --node.data=false --discovery.zen.minimum_master_nodes=2 --path.data=/tmp/
-start_node es_master3 "-p 9203:9200" --node.master=true --node.data=false --discovery.zen.minimum_master_nodes=2 --path.data=/tmp/
+start_node esmaster1 "-p 9201:9200" --node.master=true --node.data=false --discovery.zen.minimum_master_nodes=2 --path.data=/tmp/
+start_node esmaster2 "-p 9202:9200" --node.master=true --node.data=false --discovery.zen.minimum_master_nodes=2 --path.data=/tmp/
+start_node esmaster3 "-p 9203:9200" --node.master=true --node.data=false --discovery.zen.minimum_master_nodes=2 --path.data=/tmp/
 
 
 mkdir -p /tmp/es/{1,2,3}
-start_node es_data1 "-p 9211:9200 -v /tmp/es/1:/data" --node.master=false --node.data=true --path.data=/data 
-start_node es_data2 "-p 9212:9200 -v /tmp/es/2:/data" --node.master=false --node.data=true --path.data=/data
-start_node es_data3 "-p 9213:9200 -v /tmp/es/3:/data" --node.master=false --node.data=true --path.data=/data
+start_node esdata1 "-p 9211:9200 -v /tmp/es/1:/data" --node.master=false --node.data=true --path.data=/data
+start_node esdata2 "-p 9212:9200 -v /tmp/es/2:/data" --node.master=false --node.data=true --path.data=/data
+start_node esdata3 "-p 9213:9200 -v /tmp/es/3:/data" --node.master=false --node.data=true --path.data=/data
 
-start_node es_client "-p 9200:9200 -p 9300:9300" --node.master=false --node.data=false
+start_node esclient "-p 9200:9200 -p 9300:9300" --node.master=false --node.data=false

--- a/cluster-up.sh
+++ b/cluster-up.sh
@@ -3,9 +3,12 @@
 set -ex
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "[OS X] Prepare VM for Docker..."
-    docker-machine start
-    eval $(docker-machine env)
+    st=`docker-machine status`
+    if [[ ${st} != "Running"  ]]; then
+        echo "[OS X] Prepare VM for Docker..."
+        docker-machine start
+        eval $(docker-machine env)
+    fi
 fi
 
 start_node() {
@@ -17,14 +20,14 @@ start_node() {
        --node.name=$1 --cluster.name=esaas ${@:3}
 }
 
-start_node esmaster1 "-p 9201:9200" --node.master=true --node.data=false --discovery.zen.minimum_master_nodes=2 --path.data=/tmp/
-start_node esmaster2 "-p 9202:9200" --node.master=true --node.data=false --discovery.zen.minimum_master_nodes=2 --path.data=/tmp/
-start_node esmaster3 "-p 9203:9200" --node.master=true --node.data=false --discovery.zen.minimum_master_nodes=2 --path.data=/tmp/
+start_node es-master1 "-p 9201:9200" --node.master=true --node.data=false --discovery.zen.minimum_master_nodes=2 --path.data=/tmp/
+start_node es-master2 "-p 9202:9200" --node.master=true --node.data=false --discovery.zen.minimum_master_nodes=2 --path.data=/tmp/
+start_node es-master3 "-p 9203:9200" --node.master=true --node.data=false --discovery.zen.minimum_master_nodes=2 --path.data=/tmp/
 
 
 mkdir -p /tmp/es/{1,2,3}
-start_node esdata1 "-p 9211:9200 -v /tmp/es/1:/data" --node.master=false --node.data=true --path.data=/data
-start_node esdata2 "-p 9212:9200 -v /tmp/es/2:/data" --node.master=false --node.data=true --path.data=/data
-start_node esdata3 "-p 9213:9200 -v /tmp/es/3:/data" --node.master=false --node.data=true --path.data=/data
+start_node es-data1 "-p 9211:9200 -v /tmp/es/1:/data" --node.master=false --node.data=true --path.data=/data
+start_node es-data2 "-p 9212:9200 -v /tmp/es/2:/data" --node.master=false --node.data=true --path.data=/data
+start_node es-data3 "-p 9213:9200 -v /tmp/es/3:/data" --node.master=false --node.data=true --path.data=/data
 
-start_node esclient "-p 9200:9200 -p 9300:9300" --node.master=false --node.data=false
+start_node es-client "-p 9200:9200 -p 9300:9300" --node.master=false --node.data=false


### PR DESCRIPTION
Since Docker invented new validation policy for host names (see issues [#20371](https://github.com/docker/docker/issues/20371) and [#20566](https://github.com/docker/docker/pull/20566)), it is no more possible to use underscores in host names on new Docker versions. 
Also, OS X support was added. 
